### PR TITLE
Optimize stats collection

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,6 +49,8 @@ pub fn run() {
             trace::block_latencystats,
             trace::ufs_sizestats,
             trace::block_sizestats,
+            trace::ufs_allstats,
+            trace::block_allstats,
             trace::ufs_continuity_stats,
             trace::block_continuity_stats,
             trace::export_to_csv,

--- a/src-tauri/src/trace/mod.rs
+++ b/src-tauri/src/trace/mod.rs
@@ -139,6 +139,19 @@ pub async fn ufs_sizestats(
 }
 
 #[tauri::command]
+pub async fn ufs_allstats(
+    logname: String,
+    zoom_column: String,
+    time_from: Option<f64>,
+    time_to: Option<f64>,
+    col_from: Option<f64>,
+    col_to: Option<f64>,
+    thresholds: Vec<String>,
+) -> Result<Vec<u8>, String> {
+    ufs::allstats(logname, zoom_column, time_from, time_to, col_from, col_to, thresholds).await
+}
+
+#[tauri::command]
 pub async fn block_latencystats(
     logname: String,
     column: String,
@@ -186,6 +199,20 @@ pub async fn block_sizestats(
         group,
     )
     .await
+}
+
+#[tauri::command]
+pub async fn block_allstats(
+    logname: String,
+    zoom_column: String,
+    time_from: Option<f64>,
+    time_to: Option<f64>,
+    col_from: Option<f64>,
+    col_to: Option<f64>,
+    thresholds: Vec<String>,
+    group: bool,
+) -> Result<Vec<u8>, String> {
+    block::allstats(logname, zoom_column, time_from, time_to, col_from, col_to, thresholds, group).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/trace/types.rs
+++ b/src-tauri/src/trace/types.rs
@@ -123,3 +123,12 @@ pub struct TotalContinuity {
     pub continuous_bytes: u64,      // 연속 바이트 수
     pub bytes_ratio: f64,           // 연속 바이트 비율
 }
+
+#[derive(Serialize, Debug, Clone)]
+pub struct TraceStats {
+    pub dtoc_stat: LatencyStats,
+    pub ctod_stat: LatencyStats,
+    pub ctoc_stat: LatencyStats,
+    pub size_counts: SizeStats,
+    pub continuity: ContinuityStats,
+}


### PR DESCRIPTION
## Summary
- add `TraceStats` struct for unified stats
- compute UFS and Block stats in one pass
- expose `ufs_allstats` and `block_allstats` Tauri commands
- adjust TypeScript to use new combined stats commands

## Testing
- `npm run check` *(fails: svelte-kit not found)*
- `cargo check` in `src-tauri` *(fails: could not download crates)*